### PR TITLE
old haskell example tested and added.

### DIFF
--- a/use_examples/old_haskell.hs
+++ b/use_examples/old_haskell.hs
@@ -1,0 +1,44 @@
+module Main (main) where
+
+-- Somewhat old example in haskell. Some changes might be in place.
+
+-- requires: network, random, bytestring
+import Data.ByteString as ByteString hiding (map, putStrLn, mapAccumL)
+import Data.List (mapAccumL)
+import Data.Word
+import Network.Socket hiding (send, sendTo)
+import Network.Socket.ByteString (send, sendTo)
+import System.Random
+
+
+light :: Word8 -> (Word8, Word8, Word8) -> ByteString
+light n (r, g, b) =
+  ByteString.pack [1, n, 0, r, g, b]
+
+
+main :: IO()
+main = withSocketsDo $ do
+  let hints = defaultHints
+  (addr:_) <- getAddrInfo (Just hints) (Just "10.0.69.214") (Just "9909")
+  -- print addr
+  let realAddr = addrAddress addr
+
+  s <- socket AF_INET Datagram 0
+  bind s (SockAddrInet 0 iNADDR_ANY)
+
+  r <- getStdGen
+  let lightIds = [0..23] :: [Word8]
+  let (_, lightCmds) = mapAccumL (\g n -> randomLight n g) r lightIds
+
+  let payload = ByteString.concat (ByteString.pack [1, 0, 0]:lightCmds)
+  _ <- sendTo s payload realAddr
+  return ()
+
+  where
+    randomLight :: Word8 -> StdGen -> (StdGen, ByteString)
+    randomLight n r =
+     (g3, light n (red, green, blue))
+     where
+       (red,   g1) = random r
+       (green, g2) = random g1
+       (blue,  g3) = random g2


### PR DESCRIPTION
Gives warning:

27:26: warning: [-Wdeprecations]
    In the use of ‘iNADDR_ANY’ (imported from Network.Socket):
    Deprecated: "Use getAddrInfo instead"
   |
27 |   bind s (SockAddrInet 0 iNADDR_ANY)
   |     

I plan on looking trough this more carefully later on and writing a more complete and modern version once I get other stuff out of the way. The warning itself is probably trivially easy to fix.